### PR TITLE
Update syllabus link to 2024-25 on main page (dsc-capstone.org)

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,7 +22,7 @@ Here, "last year" refers to the 2023-24 academic year.
 **For students**:
 
 - [course website](https://dsc-capstone.org/2024-25). Specific subpages:
-    - The [syllabus](https://dsc-capstone.org/2023-24/syllabus).
+    - The [syllabus](https://dsc-capstone.org/2024-25/syllabus).
     - The [Quarter 2 Project specifications](https://dsc-capstone.org/2024-25/assignments/projects/q2).
 
 **For mentors**:


### PR DESCRIPTION
Hi, it looks like the frontpage of dsc-capstone.org updated all the subpage links to 2024-25 except the syllabus.